### PR TITLE
Nextcloud fix

### DIFF
--- a/nextcloud-pure.yaml
+++ b/nextcloud-pure.yaml
@@ -35,6 +35,8 @@ spec:
             value: "admin"
           - name: NEXTCLOUD_ADMIN_PASSWORD
             value: "admin"
+          - name: NEXTCLOUD_TRUSTED_DOMAINS
+            value: "10.62.204.250"  # Change to the IP address or domain that you will use to access NextCloud.
           - name: SQLITE_DATABASE
             value: "nextcloud"
         ports:


### PR DESCRIPTION
Nextcloud has pushed new changes that require the trusted domains to be setup. This is a quick "hack" to demonstrate how to set this variable, although this version is hardcoded to one particular IP private address in my cluster so won't work for other users without modification.